### PR TITLE
Fix clippy lints and dead code warnings

### DIFF
--- a/server/src/backpressure.rs
+++ b/server/src/backpressure.rs
@@ -35,6 +35,10 @@ impl<T> BoundedQueue<T> {
     pub fn len(&self) -> usize {
         self.queue.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -56,7 +56,7 @@ async fn create_room(
         ServerError::with_source(
             crate::errors::ErrorCode::Internal,
             "failed to create room",
-            err.into(),
+            err,
         )
     })?;
     Ok(Json(bootstrap))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,16 +1,4 @@
-mod auth;
-mod backpressure;
-mod config;
-mod errors;
-mod http;
-mod matchmaker;
-mod metrics;
-mod presence;
-mod protocol;
-mod rate_limit;
-mod room;
-pub mod sim;
-mod ws;
+use server::{config, http};
 
 use anyhow::Context;
 use axum::Router;

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -50,7 +50,7 @@ impl Room {
         self.simulation.ensure_player(&mut self.state, player_id);
         self.inputs
             .entry(player_id.to_string())
-            .or_insert_with(VecDeque::new);
+            .or_default();
     }
 
     pub fn push_input(&mut self, player_id: &str, event: InputEvent) -> Result<(), ServerError> {
@@ -68,7 +68,7 @@ impl Room {
         let queue = self
             .inputs
             .entry(player_id.to_string())
-            .or_insert_with(VecDeque::new);
+            .or_default();
         queue.push_back(event);
         Ok(())
     }

--- a/server/src/sim/rng.rs
+++ b/server/src/sim/rng.rs
@@ -9,7 +9,7 @@ impl SplitMix64 {
     }
 
     #[inline]
-    pub fn next(&mut self) -> u64 {
+    pub fn next_u64(&mut self) -> u64 {
         let mut z = self.state.wrapping_add(0x9E3779B97F4A7C15);
         self.state = z;
         z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
@@ -18,7 +18,15 @@ impl SplitMix64 {
     }
 
     pub fn next_f64(&mut self) -> f64 {
-        (self.next() >> 11) as f64 / ((1u64 << 53) as f64)
+        (self.next_u64() >> 11) as f64 / ((1u64 << 53) as f64)
+    }
+}
+
+impl Iterator for SplitMix64 {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.next_u64())
     }
 }
 
@@ -29,7 +37,7 @@ mod tests {
     #[test]
     fn splitmix64_known_values() {
         let mut rng = SplitMix64::new(0);
-        assert_eq!(rng.next(), 16294208416658607535);
-        assert_eq!(rng.next(), 7960286522194355700);
+        assert_eq!(rng.next(), Some(16294208416658607535));
+        assert_eq!(rng.next(), Some(7960286522194355700));
     }
 }

--- a/server/src/sim/snapshot.rs
+++ b/server/src/sim/snapshot.rs
@@ -3,6 +3,12 @@ use std::collections::HashMap;
 
 pub struct SnapshotBuilder;
 
+impl Default for SnapshotBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SnapshotBuilder {
     pub fn new() -> Self {
         Self


### PR DESCRIPTION
## Summary
- add missing helper methods and defaults to satisfy Clippy
- clean up redundant conversions and prefer crate library modules in the binary
- implement Iterator for SplitMix64 and adjust call sites

## Testing
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d3ccbd9130832dbcde6cb2f0e6e5eb