### PR TITLE
Fix formatting in room input queues

### DIFF
--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -48,9 +48,7 @@ impl Room {
 
     pub fn register_player(&mut self, player_id: &str) {
         self.simulation.ensure_player(&mut self.state, player_id);
-        self.inputs
-            .entry(player_id.to_string())
-            .or_default();
+        self.inputs.entry(player_id.to_string()).or_default();
     }
 
     pub fn push_input(&mut self, player_id: &str, event: InputEvent) -> Result<(), ServerError> {
@@ -65,10 +63,7 @@ impl Room {
                 "input outside acceptance window",
             ));
         }
-        let queue = self
-            .inputs
-            .entry(player_id.to_string())
-            .or_default();
+        let queue = self.inputs.entry(player_id.to_string()).or_default();
         queue.push_back(event);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- format `register_player` and `push_input` to comply with rustfmt defaults

## Testing
- cargo fmt --all -- --check

------
https://chatgpt.com/codex/tasks/task_e_68d3ce821c18832db706f47056af5bdc