### PR TITLE
Fix tracing env filter regex parse error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand 0.8.5",
+ "regex",
  "serde",
  "serde_json",
  "serde_with",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,6 +23,7 @@ url = "=2.3.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "env-filter", "json"] }
 tower = "0.4"
+regex = { version = "1", default-features = false, features = ["std", "unicode", "unicode-case"] }
 
 [dev-dependencies]
 axum = { version = "0.6", features = ["macros", "ws"] }


### PR DESCRIPTION
## Summary
- enable unicode-aware regex support to allow tracing-subscriber env filter to parse case-insensitive directives

## Testing
- cargo run -p server
- cargo test -p server

------
https://chatgpt.com/codex/tasks/task_e_68d3d1b64fbc832d927c929c8bcc5f9a