### PR TITLE
Skip pushing Docker image when actor lacks registry permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    env:
+      PUSH_IMAGE: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
       packages: write
@@ -23,6 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: env.PUSH_IMAGE == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -44,6 +47,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ env.PUSH_IMAGE == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- add a workflow variable to detect whether the current run is allowed to push an image
- skip the registry login and push when the actor is Dependabot so pushes from bots continue to succeed

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4b96dd950832da3a5e76ebe01aedf