### PR TITLE
Implement protocol-aligned matchmaking and realtime fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -490,6 +491,30 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-axum = { version = "0.6", features = ["macros", "ws"] }
+axum = { version = "0.6", features = ["macros", "ws", "headers"] }
 base64 = "0.21"
 dashmap = "5"
 hmac = "0.12"
@@ -27,7 +27,7 @@ regex = { version = "1", default-features = false, features = ["std", "unicode",
 futures-util = "0.3"
 
 [dev-dependencies]
-axum = { version = "0.6", features = ["macros", "ws"] }
+axum = { version = "0.6", features = ["macros", "ws", "headers"] }
 insta = "1"
 proptest = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "test-util"] }

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -10,8 +10,9 @@ use crate::{
 };
 use axum::{
     extract::{Path, State},
+    headers::{authorization::Bearer, Authorization},
     routing::{get, post},
-    Json, Router,
+    Json, Router, TypedHeader,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -54,7 +55,7 @@ async fn create_room(
     State(state): State<Arc<HttpState>>,
     Json(request): Json<CreateRoomRequest>,
 ) -> Result<(axum::http::StatusCode, Json<CreateRoomResponse>), ServerError> {
-    let bootstrap = state.matchmaker.create_room(request)?;
+    let bootstrap = state.matchmaker.create_room(request).await?;
     Ok((axum::http::StatusCode::CREATED, Json(bootstrap)))
 }
 
@@ -68,15 +69,26 @@ async fn join_room(
     State(state): State<Arc<HttpState>>,
     Json(request): Json<JoinRoomRequest>,
 ) -> Result<Json<JoinRoomResponse>, ServerError> {
-    let bootstrap = state.matchmaker.join_room(&path.room_id, request)?;
+    let bootstrap = state.matchmaker.join_room(&path.room_id, request).await?;
     Ok(Json(bootstrap))
 }
 
 async fn leave_room(
     Path(path): Path<JoinPath>,
     State(state): State<Arc<HttpState>>,
+    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
 ) -> Result<axum::http::StatusCode, ServerError> {
-    state.matchmaker.leave_room(&path.room_id, "placeholder");
+    let claims = state.token_issuer.verify_ws_token(auth.token())?;
+    if claims.room_id != path.room_id {
+        return Err(ServerError::new(
+            crate::errors::ErrorCode::Unauthorized,
+            "token does not match room",
+        ));
+    }
+    state
+        .matchmaker
+        .leave_room(&path.room_id, &claims.player_id)
+        .await;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 

--- a/server/src/matchmaker.rs
+++ b/server/src/matchmaker.rs
@@ -255,7 +255,7 @@ impl Matchmaker {
     pub fn status(&self) -> StatusResponse {
         let samples = self.latency_samples.load(Ordering::Relaxed);
         let avg_ping = if samples == 0 {
-            (1000 / self.config.snapshot_rate_hz.max(1)) as u32
+            1000 / self.config.snapshot_rate_hz.max(1)
         } else {
             let sum = self.latency_sum_ms.load(Ordering::Relaxed);
             (sum / samples.max(1)) as u32

--- a/server/src/matchmaker.rs
+++ b/server/src/matchmaker.rs
@@ -3,12 +3,16 @@ use crate::{
     config::Config,
     errors::{ErrorCode, ServerError},
     protocol::{RoomSeed, SERVER_PV},
+    room::{RoomConfig, RoomRuntime},
 };
 use dashmap::{DashMap, DashSet};
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use tokio::sync::RwLock;
 
 #[derive(Clone)]
@@ -16,9 +20,10 @@ pub struct Matchmaker {
     rooms: Arc<DashMap<String, Arc<RoomEntry>>>,
     token_issuer: TokenIssuer,
     config: Config,
+    latency_sum_ms: Arc<AtomicU64>,
+    latency_samples: Arc<AtomicU64>,
 }
 
-#[derive(Debug)]
 pub struct RoomEntry {
     pub room_id: String,
     pub seed: RoomSeed,
@@ -26,6 +31,7 @@ pub struct RoomEntry {
     pub players: DashMap<String, PlayerRecord>,
     pub names: DashSet<String>,
     pub resume_tokens: Arc<RwLock<HashMap<String, String>>>,
+    pub runtime: Arc<RoomRuntime>,
 }
 
 #[derive(Debug, Clone)]
@@ -87,10 +93,12 @@ impl Matchmaker {
             rooms: Arc::new(DashMap::new()),
             token_issuer,
             config,
+            latency_sum_ms: Arc::new(AtomicU64::new(0)),
+            latency_samples: Arc::new(AtomicU64::new(0)),
         }
     }
 
-    pub fn create_room(
+    pub async fn create_room(
         &self,
         request: CreateRoomRequest,
     ) -> Result<CreateRoomResponse, ServerError> {
@@ -117,6 +125,17 @@ impl Matchmaker {
 
         let room_id = self.generate_room_id();
         let seed = RoomSeed::random();
+        let room_config = RoomConfig {
+            max_rollback_ticks: self.config.max_rollback_ticks,
+            input_lead_ticks: self.config.input_lead_ticks,
+        };
+        let runtime = RoomRuntime::new(
+            room_id.clone(),
+            seed.as_u64(),
+            room_config,
+            self.config.tick_rate_hz,
+            self.config.snapshot_rate_hz,
+        );
         let entry = Arc::new(RoomEntry {
             room_id: room_id.clone(),
             seed,
@@ -124,24 +143,29 @@ impl Matchmaker {
             players: DashMap::new(),
             names: DashSet::new(),
             resume_tokens: Arc::new(RwLock::new(HashMap::new())),
+            runtime: runtime.clone(),
         });
         self.rooms.insert(room_id.clone(), entry.clone());
 
         let player_id = self.generate_player_id();
+        let host_name = request.name.clone();
         entry.players.insert(
             player_id.clone(),
             PlayerRecord {
-                name: request.name.clone(),
+                name: host_name.clone(),
             },
         );
-        entry.names.insert(request.name);
+        entry.names.insert(host_name.clone());
         let ws_token = match self
             .token_issuer
             .mint_ws_token(WsTokenClaims::new(room_id.clone(), player_id.clone()))
         {
             Ok(token) => token,
             Err(err) => {
+                entry.players.remove(&player_id);
+                entry.names.remove(&host_name);
                 self.rooms.remove(&room_id);
+                runtime.shutdown().await;
                 return Err(ServerError::with_source(
                     ErrorCode::Internal,
                     "failed to mint token",
@@ -149,6 +173,7 @@ impl Matchmaker {
                 ));
             }
         };
+        runtime.register_player(&player_id).await;
         Ok(CreateRoomResponse {
             room_id,
             seed,
@@ -158,7 +183,7 @@ impl Matchmaker {
         })
     }
 
-    pub fn join_room(
+    pub async fn join_room(
         &self,
         room_id: &str,
         request: JoinRoomRequest,
@@ -185,6 +210,7 @@ impl Matchmaker {
             },
         );
         entry.names.insert(player_name.clone());
+        let runtime = entry.runtime.clone();
         let ws_token = match self
             .token_issuer
             .mint_ws_token(WsTokenClaims::new(room_id.to_string(), player_id.clone()))
@@ -196,6 +222,8 @@ impl Matchmaker {
                 return Err(ServerError::new(ErrorCode::Unauthorized, "token error"));
             }
         };
+        drop(entry);
+        runtime.register_player(&player_id).await;
         Ok(JoinRoomResponse {
             room_id: room_id.to_string(),
             ws_url: self.config.ws_url.clone(),
@@ -203,22 +231,39 @@ impl Matchmaker {
         })
     }
 
-    pub fn leave_room(&self, room_id: &str, player_id: &str) {
+    pub async fn leave_room(&self, room_id: &str, player_id: &str) {
         if let Some(entry) = self.rooms.get(room_id) {
-            if let Some(record) = entry.players.remove(player_id) {
-                entry.names.remove(&record.1.name);
+            let runtime = entry.runtime.clone();
+            let removed = entry.players.remove(player_id);
+            let had_player = removed.is_some();
+            if let Some((_, record)) = removed.as_ref() {
+                entry.names.remove(&record.name);
             }
-            if entry.players.is_empty() {
-                self.rooms.remove(room_id);
+            let empty = entry.players.is_empty();
+            drop(entry);
+            if had_player {
+                runtime.deregister_player(player_id).await;
+            }
+            if empty {
+                if let Some((_, entry)) = self.rooms.remove(room_id) {
+                    entry.runtime.shutdown().await;
+                }
             }
         }
     }
 
     pub fn status(&self) -> StatusResponse {
+        let samples = self.latency_samples.load(Ordering::Relaxed);
+        let avg_ping = if samples == 0 {
+            (1000 / self.config.snapshot_rate_hz.max(1)) as u32
+        } else {
+            let sum = self.latency_sum_ms.load(Ordering::Relaxed);
+            (sum / samples.max(1)) as u32
+        };
         StatusResponse {
             regions: vec![RegionStatus {
                 id: self.config.region.clone(),
-                ping_ms: 0,
+                ping_ms: avg_ping.max(1),
                 ws_url: self.config.ws_url.clone(),
             }],
             server_pv: SERVER_PV,
@@ -281,5 +326,14 @@ impl Matchmaker {
                 .get(player_id)
                 .map(|record| record.name.clone())
         })
+    }
+
+    pub fn room_runtime(&self, room_id: &str) -> Option<Arc<RoomRuntime>> {
+        self.rooms.get(room_id).map(|entry| entry.runtime.clone())
+    }
+
+    pub fn record_latency_sample(&self, millis: u64) {
+        self.latency_sum_ms.fetch_add(millis, Ordering::Relaxed);
+        self.latency_samples.fetch_add(1, Ordering::Relaxed);
     }
 }

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -195,7 +195,8 @@ impl OutboundMessage {
 pub struct JoinPayload {
     pub name: String,
     pub client_version: String,
-    pub device: String,
+    #[serde(default)]
+    pub device: Option<String>,
     #[serde(default)]
     pub capabilities: HashMap<String, bool>,
 }
@@ -357,8 +358,6 @@ pub struct SnapshotStats {
 pub struct PongPayload {
     pub t0: u64,
     pub t1: u64,
-    #[serde(default)]
-    pub t2: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -4,6 +4,9 @@ use crate::{
     sim::{PlayerInputSample, Simulation, SimulationState},
 };
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use tokio::sync::{watch, Mutex};
+use tokio::time::{self, Duration, Instant};
 
 #[derive(Clone)]
 pub struct RoomConfig {
@@ -64,7 +67,21 @@ impl Room {
                 "input outside acceptance window",
             ));
         }
+        if !(event.axis_x >= -1.25 && event.axis_x <= 1.25) {
+            return Err(ServerError::new(
+                ErrorCode::CheatDetected,
+                "axis_x out of range",
+            ));
+        }
         let queue = self.inputs.entry(player_id.to_string()).or_default();
+        if let Some(last) = queue.back() {
+            if event.tick + 1 < last.tick {
+                return Err(ServerError::new(
+                    ErrorCode::CheatDetected,
+                    "inputs arrived out of order",
+                ));
+            }
+        }
         queue.push_back(event);
         Ok(())
     }
@@ -94,12 +111,127 @@ impl Room {
         self.simulation.step(&mut self.state, &inputs);
     }
 
-    pub fn snapshot(&self, full: bool) -> SnapshotPayload {
-        self.simulation.build_snapshot(&self.state, full)
+    pub fn snapshot_for_player(&self, player_id: &str, full: bool) -> SnapshotPayload {
+        self.simulation
+            .build_snapshot(&self.state, full, Some(player_id))
     }
 
     pub fn tick(&self) -> u64 {
         self.state.tick
+    }
+
+    pub fn deregister_player(&mut self, player_id: &str) {
+        self.inputs.remove(player_id);
+        self.simulation.remove_player(&mut self.state, player_id);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SnapshotSignal {
+    pub tick: u64,
+    pub full: bool,
+}
+
+pub struct RoomRuntime {
+    room: Mutex<Room>,
+    snapshot_tx: watch::Sender<SnapshotSignal>,
+    tick_duration: Duration,
+    snapshot_interval_ticks: u64,
+    full_snapshot_interval_ticks: u64,
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl RoomRuntime {
+    pub fn new(
+        room_id: impl Into<String>,
+        seed: u64,
+        config: RoomConfig,
+        tick_rate: u32,
+        snapshot_rate: u32,
+    ) -> Arc<Self> {
+        let room = Room::new(room_id, seed, config.clone());
+        let snapshot_interval_ticks = (tick_rate / snapshot_rate.max(1)) as u64;
+        let full_snapshot_interval_ticks = tick_rate as u64;
+        let (snapshot_tx, _) = watch::channel(SnapshotSignal {
+            tick: 0,
+            full: true,
+        });
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let runtime = Arc::new(Self {
+            room: Mutex::new(room),
+            snapshot_tx,
+            tick_duration: Duration::from_secs_f64(1.0 / tick_rate.max(1) as f64),
+            snapshot_interval_ticks: snapshot_interval_ticks.max(1),
+            full_snapshot_interval_ticks: full_snapshot_interval_ticks.max(1),
+            shutdown_tx,
+        });
+        Self::spawn_loop(runtime.clone(), shutdown_rx);
+        runtime
+    }
+
+    fn spawn_loop(runtime: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+        tokio::spawn(async move {
+            let mut ticker = time::interval_at(Instant::now(), runtime.tick_duration);
+            ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        let mut guard = runtime.room.lock().await;
+                        guard.step();
+                        let tick = guard.tick();
+                        let should_snapshot = tick % runtime.snapshot_interval_ticks == 0;
+                        let full = tick % runtime.full_snapshot_interval_ticks == 0;
+                        drop(guard);
+                        if should_snapshot {
+                            let _ = runtime.snapshot_tx.send(SnapshotSignal { tick, full });
+                        }
+                    }
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_ok() && *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    pub async fn register_player(&self, player_id: &str) {
+        let mut guard = self.room.lock().await;
+        guard.register_player(player_id);
+    }
+
+    pub async fn deregister_player(&self, player_id: &str) {
+        let mut guard = self.room.lock().await;
+        guard.deregister_player(player_id);
+    }
+
+    pub async fn push_input(&self, player_id: &str, event: InputEvent) -> Result<(), ServerError> {
+        let mut guard = self.room.lock().await;
+        guard.push_input(player_id, event)
+    }
+
+    pub async fn snapshot_for_player(&self, player_id: &str, full: bool) -> SnapshotPayload {
+        let guard = self.room.lock().await;
+        guard.snapshot_for_player(player_id, full)
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<SnapshotSignal> {
+        self.snapshot_tx.subscribe()
+    }
+
+    pub async fn latest_full_snapshot(&self, player_id: &str) -> SnapshotPayload {
+        let guard = self.room.lock().await;
+        guard.snapshot_for_player(player_id, true)
+    }
+
+    pub async fn tick(&self) -> u64 {
+        let guard = self.room.lock().await;
+        guard.tick()
+    }
+
+    pub async fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
     }
 }
 
@@ -122,7 +254,7 @@ mod tests {
         )
         .unwrap();
         room.step();
-        let snap = room.snapshot(true);
+        let snap = room.snapshot_for_player("p1", true);
         assert_eq!(snap.tick, 1);
         assert_eq!(snap.players.len(), 1);
         assert!(snap.players[0].y > 0.0);

--- a/server/src/sim/mod.rs
+++ b/server/src/sim/mod.rs
@@ -33,6 +33,11 @@ impl Simulation {
 
     pub fn step(&self, state: &mut SimulationState, inputs: &[(String, PlayerInputSample)]) {
         state.tick = state.tick.saturating_add(1);
+        for player in state.players.values_mut() {
+            player.vy = (player.vy - 200.0).max(-2200.0);
+            player.y = (player.y + player.vy / 60.0).max(0.0);
+            player.x = player.x.clamp(0.0, 1080.0);
+        }
         for (player_id, sample) in inputs {
             let entry = state
                 .players
@@ -41,22 +46,24 @@ impl Simulation {
                     player_id: player_id.clone(),
                     ..Default::default()
                 });
-            entry.vx = sample.axis_x * 900.0;
+            entry.vx = (sample.axis_x * 900.0).clamp(-900.0, 900.0);
+            entry.x = (entry.x + entry.vx / 60.0).clamp(0.0, 1080.0);
             if sample.jump {
                 entry.vy = 1200.0;
-                entry.y += 18.0;
-            } else {
-                entry.vy = (entry.vy - 200.0).max(-2200.0);
                 entry.y = (entry.y + entry.vy / 60.0).max(0.0);
             }
-            entry.x = (entry.x + entry.vx / 60.0).clamp(0.0, 1080.0);
             if entry.last_input_seq < sample.seq {
                 entry.last_input_seq = sample.seq;
             }
         }
     }
 
-    pub fn build_snapshot(&self, state: &SimulationState, full: bool) -> SnapshotPayload {
+    pub fn build_snapshot(
+        &self,
+        state: &SimulationState,
+        full: bool,
+        player_id: Option<&str>,
+    ) -> SnapshotPayload {
         let mut players: Vec<PlayerSnapshot> = state
             .players
             .values()
@@ -76,10 +83,15 @@ impl Simulation {
             .map(|p| p.last_input_seq)
             .max()
             .unwrap_or(0);
+        let ack_tick = state.tick;
+        let player_ack_seq = player_id
+            .and_then(|id| state.players.get(id))
+            .map(|p| p.last_input_seq)
+            .unwrap_or(last_input_seq);
         SnapshotPayload {
             tick: state.tick,
-            ack_tick: state.tick.saturating_sub(1),
-            last_input_seq,
+            ack_tick,
+            last_input_seq: player_ack_seq,
             full,
             players,
             events: Vec::new(),
@@ -95,5 +107,9 @@ impl Simulation {
                 player_id: player_id.to_string(),
                 ..Default::default()
             });
+    }
+
+    pub fn remove_player(&self, state: &mut SimulationState, player_id: &str) {
+        state.players.remove(player_id);
     }
 }

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -1,22 +1,29 @@
 use crate::{
     auth::WsTokenClaims,
+    backpressure::BoundedQueue,
     errors::{ErrorCode, ServerError},
     http::HttpState,
     protocol::{
         self, DifficultyConfig, ErrorPayload, InboundMessage, OutboundMessage, PongPayload,
-        SessionConfig, SnapshotEvent, SnapshotPayload, SnapshotStats, StartPayload, WelcomePayload,
-        WorldConfig,
+        SessionConfig, SnapshotEvent, StartPayload, WelcomePayload, WorldConfig,
     },
+    rate_limit::LeakyBucket,
 };
+use axum::extract::ws::Message;
 use axum::{
     extract::{ws::WebSocketUpgrade, Query, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
 };
-use futures_util::StreamExt;
+use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+    Arc,
+};
+use tokio::sync::{Mutex, Notify};
+use tokio::task::JoinHandle;
 
 pub async fn upgrade_handler(
     State(state): State<Arc<HttpState>>,
@@ -63,76 +70,93 @@ pub async fn upgrade_handler(
 }
 
 async fn drive_socket(
-    mut socket: axum::extract::ws::WebSocket,
+    socket: axum::extract::ws::WebSocket,
     state: Arc<HttpState>,
     claims: WsTokenClaims,
 ) -> Result<(), ServerError> {
-    let mut seq_counter: u64 = 1;
-    let mut last_ack_tick = 0;
-    let mut last_input_seq = 0;
-    let mut joined = false;
-
+    let runtime = state
+        .matchmaker
+        .room_runtime(&claims.room_id)
+        .ok_or_else(|| ServerError::new(ErrorCode::RoomNotFound, "room not found"))?;
     let seed = state
         .matchmaker
         .room_seed(&claims.room_id)
         .ok_or_else(|| ServerError::new(ErrorCode::RoomNotFound, "room not found"))?;
 
-    while let Some(result) = socket.next().await {
+    let pump = OutboundPump::new(256);
+    let seq_counter = Arc::new(AtomicU64::new(1));
+    let dropped_counter = Arc::new(AtomicU32::new(0));
+    let (mut sender, mut receiver) = socket.split();
+    let pump_writer = pump.clone();
+    let send_task = tokio::spawn(async move {
+        while let Some(pending) = pump_writer.pop().await {
+            send_pending(&mut sender, pending).await?;
+        }
+        Ok::<(), ServerError>(())
+    });
+
+    let mut joined = false;
+    let mut snapshot_task: Option<JoinHandle<()>> = None;
+    let mut input_bucket = LeakyBucket::new(90.0, 90.0);
+    let mut batch_bucket = LeakyBucket::new(120.0, 120.0);
+
+    while let Some(result) = receiver.next().await {
         let message = match result {
             Ok(message) => message,
             Err(err) => {
+                pump.close();
+                if let Some(task) = snapshot_task.take() {
+                    task.abort();
+                }
                 return Err(ServerError::with_source(
                     ErrorCode::Internal,
                     "websocket receive error",
                     err.into(),
-                ))
+                ));
             }
         };
 
         match message {
-            axum::extract::ws::Message::Text(text) => {
-                let inbound: InboundMessage = serde_json::from_str(&text).map_err(|err| {
-                    ServerError::with_source(ErrorCode::InvalidState, "invalid json", err.into())
-                })?;
+            Message::Text(text) => {
+                let inbound: InboundMessage = match serde_json::from_str(&text) {
+                    Ok(msg) => msg,
+                    Err(err) => {
+                        queue_error(&pump, &seq_counter, ErrorCode::InvalidState, "invalid json")
+                            .await;
+                        tracing::debug!(error = %err, "invalid inbound message");
+                        continue;
+                    }
+                };
 
                 if inbound.meta().pv != protocol::SERVER_PV {
-                    send_message(
-                        &mut socket,
-                        OutboundMessage::new_error(
-                            seq_counter,
-                            ErrorPayload {
-                                code: ErrorCode::BadVersion,
-                                message: format!(
-                                    "Server pv={}, client pv={}",
-                                    protocol::SERVER_PV,
-                                    inbound.meta().pv
-                                ),
-                            },
+                    queue_error(
+                        &pump,
+                        &seq_counter,
+                        ErrorCode::BadVersion,
+                        format!(
+                            "Server pv={}, client pv={}",
+                            protocol::SERVER_PV,
+                            inbound.meta().pv
                         ),
                     )
-                    .await?;
-                    seq_counter += 1;
+                    .await;
                     break;
                 }
 
                 match inbound {
                     InboundMessage::Join { payload, .. } => {
                         if joined {
-                            send_message(
-                                &mut socket,
-                                OutboundMessage::new_error(
-                                    seq_counter,
-                                    ErrorPayload {
-                                        code: ErrorCode::InvalidState,
-                                        message: "join already processed".to_string(),
-                                    },
-                                ),
+                            queue_error(
+                                &pump,
+                                &seq_counter,
+                                ErrorCode::InvalidState,
+                                "join already processed",
                             )
-                            .await?;
-                            seq_counter += 1;
+                            .await;
                             continue;
                         }
                         joined = true;
+                        runtime.register_player(&claims.player_id).await;
                         let resume_token = state
                             .token_issuer
                             .mint_resume_token(&claims.room_id, &claims.player_id);
@@ -157,41 +181,42 @@ async fn drive_socket(
                             cfg: session_config(&state),
                             feature_flags,
                         };
-                        send_message(
-                            &mut socket,
-                            OutboundMessage::new_welcome(seq_counter, welcome),
-                        )
-                        .await?;
-                        seq_counter += 1;
+                        pump.push_json(OutboundMessage::new_welcome(
+                            next_seq(&seq_counter),
+                            welcome,
+                        ))
+                        .await;
 
+                        let current_tick = runtime.tick().await;
                         let start_payload = StartPayload {
-                            start_tick: 0,
-                            server_tick: 0,
+                            start_tick: current_tick,
+                            server_tick: current_tick,
                             server_time_ms: current_ts_millis(),
                             tps: state.config.tick_rate_hz,
                         };
-                        send_message(
-                            &mut socket,
-                            OutboundMessage::new_start(seq_counter, start_payload),
-                        )
-                        .await?;
-                        seq_counter += 1;
+                        pump.push_json(OutboundMessage::new_start(
+                            next_seq(&seq_counter),
+                            start_payload,
+                        ))
+                        .await;
 
-                        let snapshot = SnapshotPayload {
-                            tick: 0,
-                            ack_tick: last_ack_tick,
-                            last_input_seq,
-                            full: true,
-                            players: vec![],
-                            events: vec![],
-                            stats: SnapshotStats::default(),
-                        };
-                        send_message(
-                            &mut socket,
-                            OutboundMessage::new_snapshot(seq_counter, snapshot),
-                        )
-                        .await?;
-                        seq_counter += 1;
+                        let mut snapshot =
+                            runtime.snapshot_for_player(&claims.player_id, true).await;
+                        snapshot.stats.dropped_snapshots = dropped_counter.load(Ordering::Relaxed);
+                        pump.push_json(OutboundMessage::new_snapshot(
+                            next_seq(&seq_counter),
+                            snapshot,
+                        ))
+                        .await;
+
+                        let snapshot_handle = spawn_snapshot_task(
+                            runtime.clone(),
+                            pump.clone(),
+                            seq_counter.clone(),
+                            dropped_counter.clone(),
+                            claims.player_id.clone(),
+                        );
+                        snapshot_task = Some(snapshot_handle);
 
                         tracing::info!(
                             player = %payload.name,
@@ -201,85 +226,90 @@ async fn drive_socket(
                     }
                     InboundMessage::Input { ref payload, .. } => {
                         if !joined {
-                            send_message(
-                                &mut socket,
-                                OutboundMessage::new_error(
-                                    seq_counter,
-                                    ErrorPayload {
-                                        code: ErrorCode::InvalidState,
-                                        message: "must join before sending input".to_string(),
-                                    },
-                                ),
+                            queue_error(
+                                &pump,
+                                &seq_counter,
+                                ErrorCode::InvalidState,
+                                "must join before sending input",
                             )
-                            .await?;
-                            seq_counter += 1;
+                            .await;
                             continue;
                         }
-                        last_ack_tick = payload.tick;
-                        last_input_seq = inbound.meta().seq;
-                        let ack_snapshot = SnapshotPayload {
-                            tick: last_ack_tick,
-                            ack_tick: last_ack_tick,
-                            last_input_seq,
-                            full: false,
-                            players: Vec::new(),
-                            events: Vec::new(),
-                            stats: SnapshotStats::default(),
+                        if !input_bucket.allow(1.0) {
+                            queue_error(
+                                &pump,
+                                &seq_counter,
+                                ErrorCode::RateLimited,
+                                "input rate limited",
+                            )
+                            .await;
+                            continue;
+                        }
+                        let event = crate::room::InputEvent {
+                            tick: payload.tick,
+                            seq: inbound.meta().seq,
+                            axis_x: payload.axis_x,
+                            jump: payload.jump,
                         };
-                        send_message(
-                            &mut socket,
-                            OutboundMessage::new_snapshot(seq_counter, ack_snapshot),
-                        )
-                        .await?;
-                        seq_counter += 1;
+                        if let Err(err) = runtime.push_input(&claims.player_id, event).await {
+                            queue_error(&pump, &seq_counter, err.code, err.message.clone()).await;
+                            if err.code == ErrorCode::CheatDetected {
+                                break;
+                            }
+                        }
                     }
                     InboundMessage::InputBatch { ref payload, .. } => {
                         if !joined {
-                            send_message(
-                                &mut socket,
-                                OutboundMessage::new_error(
-                                    seq_counter,
-                                    ErrorPayload {
-                                        code: ErrorCode::InvalidState,
-                                        message: "must join before sending input".to_string(),
-                                    },
-                                ),
+                            queue_error(
+                                &pump,
+                                &seq_counter,
+                                ErrorCode::InvalidState,
+                                "must join before sending input",
                             )
-                            .await?;
-                            seq_counter += 1;
+                            .await;
                             continue;
                         }
-                        last_ack_tick = payload
-                            .frames
-                            .last()
-                            .map(|frame| payload.start_tick + frame.d as u64)
-                            .unwrap_or(payload.start_tick);
-                        last_input_seq = inbound.meta().seq;
-                        let ack_snapshot = SnapshotPayload {
-                            tick: last_ack_tick,
-                            ack_tick: last_ack_tick,
-                            last_input_seq,
-                            full: false,
-                            players: Vec::new(),
-                            events: Vec::new(),
-                            stats: SnapshotStats::default(),
-                        };
-                        send_message(
-                            &mut socket,
-                            OutboundMessage::new_snapshot(seq_counter, ack_snapshot),
-                        )
-                        .await?;
-                        seq_counter += 1;
+                        let cost = payload.frames.len().max(1) as f64;
+                        if !batch_bucket.allow(cost) {
+                            queue_error(
+                                &pump,
+                                &seq_counter,
+                                ErrorCode::RateLimited,
+                                "input batch rate limited",
+                            )
+                            .await;
+                            continue;
+                        }
+                        let mut error: Option<ServerError> = None;
+                        for frame in &payload.frames {
+                            let event = crate::room::InputEvent {
+                                tick: payload.start_tick + frame.d as u64,
+                                seq: inbound.meta().seq,
+                                axis_x: frame.axis_x,
+                                jump: frame.jump,
+                            };
+                            if let Err(err) = runtime.push_input(&claims.player_id, event).await {
+                                error = Some(err);
+                                break;
+                            }
+                        }
+                        if let Some(err) = error {
+                            queue_error(&pump, &seq_counter, err.code, err.message.clone()).await;
+                            if err.code == ErrorCode::CheatDetected {
+                                break;
+                            }
+                        }
                     }
                     InboundMessage::Ping { payload, .. } => {
+                        let now = current_ts_millis();
+                        let rtt = now.saturating_sub(payload.t0);
+                        state.matchmaker.record_latency_sample(rtt);
                         let pong = PongPayload {
                             t0: payload.t0,
-                            t1: current_ts_millis(),
-                            t2: Some(current_ts_millis()),
+                            t1: now,
                         };
-                        send_message(&mut socket, OutboundMessage::new_pong(seq_counter, pong))
-                            .await?;
-                        seq_counter += 1;
+                        pump.push_json(OutboundMessage::new_pong(next_seq(&seq_counter), pong))
+                            .await;
                     }
                     InboundMessage::Reconnect { payload, .. } => {
                         if !state
@@ -291,100 +321,207 @@ async fn drive_socket(
                             )
                             .await
                         {
-                            send_message(
-                                &mut socket,
-                                OutboundMessage::new_error(
-                                    seq_counter,
-                                    ErrorPayload {
-                                        code: ErrorCode::Unauthorized,
-                                        message: "invalid resume token".to_string(),
-                                    },
-                                ),
+                            queue_error(
+                                &pump,
+                                &seq_counter,
+                                ErrorCode::Unauthorized,
+                                "invalid resume token",
                             )
-                            .await?;
-                            seq_counter += 1;
+                            .await;
                             continue;
                         }
-                        let snapshot = SnapshotPayload {
-                            tick: payload.last_ack_tick,
-                            ack_tick: payload.last_ack_tick,
-                            last_input_seq,
-                            full: true,
-                            players: vec![],
-                            events: vec![SnapshotEvent {
-                                kind: "resume".to_string(),
-                                x: 0.0,
-                                y: 0.0,
-                                tick: payload.last_ack_tick,
-                            }],
-                            stats: SnapshotStats::default(),
-                        };
-                        send_message(
-                            &mut socket,
-                            OutboundMessage::new_snapshot(seq_counter, snapshot),
-                        )
-                        .await?;
-                        seq_counter += 1;
+                        let mut snapshot = runtime.latest_full_snapshot(&payload.player_id).await;
+                        snapshot.events.push(SnapshotEvent {
+                            kind: "resume".to_string(),
+                            x: 0.0,
+                            y: 0.0,
+                            tick: snapshot.tick,
+                        });
+                        snapshot.stats.dropped_snapshots = dropped_counter.load(Ordering::Relaxed);
+                        pump.push_json(OutboundMessage::new_snapshot(
+                            next_seq(&seq_counter),
+                            snapshot,
+                        ))
+                        .await;
                     }
                 }
             }
-            axum::extract::ws::Message::Binary(_) => {
-                send_message(
-                    &mut socket,
-                    OutboundMessage::new_error(
-                        seq_counter,
-                        ErrorPayload {
-                            code: ErrorCode::InvalidState,
-                            message: "binary frames are not supported".to_string(),
-                        },
-                    ),
+            Message::Binary(_) => {
+                queue_error(
+                    &pump,
+                    &seq_counter,
+                    ErrorCode::InvalidState,
+                    "binary frames are not supported",
                 )
-                .await?;
-                seq_counter += 1;
+                .await;
             }
-            axum::extract::ws::Message::Ping(payload) => {
-                socket
-                    .send(axum::extract::ws::Message::Pong(payload))
-                    .await
-                    .map_err(|err| {
-                        ServerError::with_source(
-                            ErrorCode::Internal,
-                            "failed to send pong",
-                            err.into(),
-                        )
-                    })?;
+            Message::Ping(payload) => {
+                pump.push_control(Message::Pong(payload)).await;
             }
-            axum::extract::ws::Message::Pong(_) => {}
-            axum::extract::ws::Message::Close(_) => {
+            Message::Pong(_) => {}
+            Message::Close(_) => {
                 break;
             }
         }
     }
 
-    if joined {
-        let finish = OutboundMessage::Finish {
-            meta: protocol::MessageMeta::new(seq_counter),
-            payload: protocol::FinishPayload {
-                reason: "room_closed".to_string(),
-            },
-        };
-        let _ = send_message(&mut socket, finish).await;
+    pump.close();
+    if let Some(task) = snapshot_task {
+        task.abort();
     }
 
-    Ok(())
+    match send_task.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Ok(()),
+    }
 }
 
-async fn send_message(
-    socket: &mut axum::extract::ws::WebSocket,
-    message: OutboundMessage,
+#[derive(Clone)]
+struct OutboundPump {
+    inner: Arc<OutboundPumpInner>,
+}
+
+struct OutboundPumpInner {
+    queue: Mutex<BoundedQueue<PendingMessage>>,
+    notify: Notify,
+    closed: AtomicBool,
+}
+
+enum PendingMessage {
+    Json(OutboundMessage),
+    Control(Message),
+}
+
+impl OutboundPump {
+    fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(OutboundPumpInner {
+                queue: Mutex::new(BoundedQueue::new(capacity)),
+                notify: Notify::new(),
+                closed: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    async fn push_json(&self, message: OutboundMessage) -> bool {
+        let mut queue = self.inner.queue.lock().await;
+        let before = queue.dropped();
+        queue.push(PendingMessage::Json(message));
+        let after = queue.dropped();
+        drop(queue);
+        self.inner.notify.notify_one();
+        after > before
+    }
+
+    async fn push_control(&self, message: Message) -> bool {
+        let mut queue = self.inner.queue.lock().await;
+        let before = queue.dropped();
+        queue.push(PendingMessage::Control(message));
+        let after = queue.dropped();
+        drop(queue);
+        self.inner.notify.notify_one();
+        after > before
+    }
+
+    async fn pop(&self) -> Option<PendingMessage> {
+        loop {
+            let mut queue = self.inner.queue.lock().await;
+            if let Some(item) = queue.pop() {
+                return Some(item);
+            }
+            if self.inner.closed.load(Ordering::Relaxed) {
+                return None;
+            }
+            let notified = self.inner.notify.notified();
+            drop(queue);
+            notified.await;
+        }
+    }
+
+    fn close(&self) {
+        if !self.inner.closed.swap(true, Ordering::Relaxed) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+}
+
+async fn send_pending(
+    sink: &mut futures_util::stream::SplitSink<axum::extract::ws::WebSocket, Message>,
+    message: PendingMessage,
 ) -> Result<(), ServerError> {
-    let text = serde_json::to_string(&message).map_err(|err| {
-        ServerError::with_source(ErrorCode::Internal, "serialization error", err.into())
-    })?;
-    socket
-        .send(axum::extract::ws::Message::Text(text))
-        .await
-        .map_err(|err| ServerError::with_source(ErrorCode::Internal, "failed to send", err.into()))
+    match message {
+        PendingMessage::Json(message) => {
+            let text = serde_json::to_string(&message).map_err(|err| {
+                ServerError::with_source(ErrorCode::Internal, "serialization error", err.into())
+            })?;
+            sink.send(Message::Text(text)).await.map_err(|err| {
+                ServerError::with_source(ErrorCode::Internal, "failed to send", err.into())
+            })
+        }
+        PendingMessage::Control(message) => sink.send(message).await.map_err(|err| {
+            ServerError::with_source(ErrorCode::Internal, "failed to send", err.into())
+        }),
+    }
+}
+
+fn next_seq(counter: &AtomicU64) -> u64 {
+    counter.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn queue_error(
+    pump: &OutboundPump,
+    seq_counter: &AtomicU64,
+    code: ErrorCode,
+    message: impl Into<String>,
+) {
+    let payload = ErrorPayload {
+        code,
+        message: message.into(),
+    };
+    let _ = pump
+        .push_json(OutboundMessage::new_error(next_seq(seq_counter), payload))
+        .await;
+}
+
+fn spawn_snapshot_task(
+    runtime: Arc<crate::room::RoomRuntime>,
+    pump: OutboundPump,
+    seq_counter: Arc<AtomicU64>,
+    dropped_counter: Arc<AtomicU32>,
+    player_id: String,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut rx = runtime.subscribe();
+        while rx.changed().await.is_ok() {
+            let signal = rx.borrow().clone();
+            if signal.tick == 0 {
+                continue;
+            }
+            let mut snapshot = runtime.snapshot_for_player(&player_id, signal.full).await;
+            snapshot.stats.dropped_snapshots = dropped_counter.load(Ordering::Relaxed);
+            if pump
+                .push_json(OutboundMessage::new_snapshot(
+                    next_seq(&seq_counter),
+                    snapshot,
+                ))
+                .await
+            {
+                let prev = dropped_counter.fetch_add(1, Ordering::Relaxed);
+                if prev == 0 {
+                    let _ = pump
+                        .push_json(OutboundMessage::new_error(
+                            next_seq(&seq_counter),
+                            ErrorPayload {
+                                code: ErrorCode::SlowConsumer,
+                                message: "client is too slow to consume snapshots".to_string(),
+                            },
+                        ))
+                        .await;
+                }
+            }
+        }
+    })
 }
 
 fn session_config(state: &HttpState) -> SessionConfig {

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -389,7 +389,7 @@ struct OutboundPumpInner {
 }
 
 enum PendingMessage {
-    Json(OutboundMessage),
+    Json(Box<OutboundMessage>),
     Control(Message),
 }
 
@@ -407,7 +407,7 @@ impl OutboundPump {
     async fn push_json(&self, message: OutboundMessage) -> bool {
         let mut queue = self.inner.queue.lock().await;
         let before = queue.dropped();
-        queue.push(PendingMessage::Json(message));
+        queue.push(PendingMessage::Json(Box::new(message)));
         let after = queue.dropped();
         drop(queue);
         self.inner.notify.notify_one();
@@ -452,7 +452,7 @@ async fn send_pending(
 ) -> Result<(), ServerError> {
     match message {
         PendingMessage::Json(message) => {
-            let text = serde_json::to_string(&message).map_err(|err| {
+            let text = serde_json::to_string(&*message).map_err(|err| {
                 ServerError::with_source(ErrorCode::Internal, "serialization error", err.into())
             })?;
             sink.send(Message::Text(text)).await.map_err(|err| {

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -1,20 +1,28 @@
 use server::auth::TokenIssuer;
 use server::config::Config;
-use server::matchmaker::Matchmaker;
-use server::protocol::RoomSeed;
+use server::matchmaker::{CreateRoomRequest, Matchmaker};
 
 #[tokio::test]
 async fn resume_token_round_trip() {
     let config = Config::default();
     let issuer = TokenIssuer::new(config.token_secret.clone());
     let matchmaker = Matchmaker::new(config.clone(), issuer.clone());
-    let bootstrap = matchmaker.create_room().unwrap();
-    let resume = issuer.mint_resume_token(&bootstrap.room_id, &bootstrap.player_id);
+    let bootstrap = matchmaker
+        .create_room(CreateRoomRequest {
+            name: "host".to_string(),
+            region: config.region.clone(),
+            max_players: 2,
+            mode: "endless".to_string(),
+        })
+        .await
+        .unwrap();
+    let claims = issuer.verify_ws_token(&bootstrap.ws_token).unwrap();
+    let resume = issuer.mint_resume_token(&bootstrap.room_id, &claims.player_id);
     matchmaker
-        .set_resume_token(&bootstrap.room_id, &bootstrap.player_id, resume.0.clone())
+        .set_resume_token(&bootstrap.room_id, &claims.player_id, resume.0.clone())
         .await;
     let valid = matchmaker
-        .validate_resume_token(&bootstrap.room_id, &bootstrap.player_id, &resume.0)
+        .validate_resume_token(&bootstrap.room_id, &claims.player_id, &resume.0)
         .await;
     assert!(valid);
 }


### PR DESCRIPTION
## Summary
- make the join payload tolerant of missing device info and align pong schema with the spec
- wire a real simulation runtime that streams snapshots, enforces tick windows, and applies backpressure and rate limits
- update matchmaking, status telemetry, and REST leave handling to track active rooms and authenticate players

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d4b947556c832da0228ab1a533f723