### PR TITLE
Fix Clippy warnings in matchmaker and websocket queue

### DIFF
--- a/server/src/matchmaker.rs
+++ b/server/src/matchmaker.rs
@@ -255,7 +255,7 @@ impl Matchmaker {
     pub fn status(&self) -> StatusResponse {
         let samples = self.latency_samples.load(Ordering::Relaxed);
         let avg_ping = if samples == 0 {
-            (1000 / self.config.snapshot_rate_hz.max(1)) as u32
+            1000 / self.config.snapshot_rate_hz.max(1)
         } else {
             let sum = self.latency_sum_ms.load(Ordering::Relaxed);
             (sum / samples.max(1)) as u32

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -389,7 +389,7 @@ struct OutboundPumpInner {
 }
 
 enum PendingMessage {
-    Json(OutboundMessage),
+    Json(Box<OutboundMessage>),
     Control(Message),
 }
 
@@ -407,7 +407,7 @@ impl OutboundPump {
     async fn push_json(&self, message: OutboundMessage) -> bool {
         let mut queue = self.inner.queue.lock().await;
         let before = queue.dropped();
-        queue.push(PendingMessage::Json(message));
+        queue.push(PendingMessage::Json(Box::new(message)));
         let after = queue.dropped();
         drop(queue);
         self.inner.notify.notify_one();
@@ -452,7 +452,7 @@ async fn send_pending(
 ) -> Result<(), ServerError> {
     match message {
         PendingMessage::Json(message) => {
-            let text = serde_json::to_string(&message).map_err(|err| {
+            let text = serde_json::to_string(&*message).map_err(|err| {
                 ServerError::with_source(ErrorCode::Internal, "serialization error", err.into())
             })?;
             sink.send(Message::Text(text)).await.map_err(|err| {


### PR DESCRIPTION
## Summary
- remove an unnecessary integer cast when computing the default average ping
- box outbound JSON messages in the websocket queue to shrink enum size

## Testing
- cargo clippy --workspace --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d4c6d5f504832d83770e558c4e53dc