### PR TITLE
Add integration tests for network protocol compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1215,6 +1215,7 @@ dependencies = [
  "dashmap",
  "futures-util",
  "hmac",
+ "hyper",
  "insta",
  "once_cell",
  "prometheus",
@@ -1227,6 +1228,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
+ "tokio-tungstenite 0.19.0",
  "toml",
  "tower",
  "tracing",
@@ -1467,6 +1469,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.19.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
@@ -1474,7 +1488,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -1580,6 +1594,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,3 +32,29 @@ insta = "1"
 proptest = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "test-util"] }
 serde_json = "1"
+tokio-tungstenite = "0.19"
+hyper = "0.14"
+
+[[test]]
+name = "determinism"
+path = "../tests/determinism.rs"
+
+[[test]]
+name = "e2e_matchmaking"
+path = "../tests/e2e_matchmaking.rs"
+
+[[test]]
+name = "e2e_ws_roundtrip"
+path = "../tests/e2e_ws_roundtrip.rs"
+
+[[test]]
+name = "rate_limit"
+path = "../tests/rate_limit.rs"
+
+[[test]]
+name = "reconnect"
+path = "../tests/reconnect.rs"
+
+[[test]]
+name = "network_spec"
+path = "../tests/network_spec.rs"

--- a/server/src/matchmaker.rs
+++ b/server/src/matchmaker.rs
@@ -39,14 +39,14 @@ pub struct PlayerRecord {
     pub name: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusResponse {
     pub regions: Vec<RegionStatus>,
     pub server_pv: u32,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegionStatus {
     pub id: String,
@@ -63,7 +63,7 @@ pub struct CreateRoomRequest {
     pub mode: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRoomResponse {
     pub room_id: String,
@@ -79,7 +79,7 @@ pub struct JoinRoomRequest {
     pub name: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JoinRoomResponse {
     pub room_id: String,

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -18,8 +18,8 @@ fn deterministic_simulation() {
         room_b.push_input("p1", input).unwrap();
         room_a.step();
         room_b.step();
-        let snap_a = room_a.snapshot(false);
-        let snap_b = room_b.snapshot(false);
+        let snap_a = room_a.snapshot_for_player("p1", true);
+        let snap_b = room_b.snapshot_for_player("p1", true);
         assert!((snap_a.players[0].y - snap_b.players[0].y).abs() < f32::EPSILON);
     }
 }

--- a/tests/e2e_matchmaking.rs
+++ b/tests/e2e_matchmaking.rs
@@ -33,6 +33,7 @@ async fn create_and_join_room() {
     let join_uri = format!("/v1/rooms/{}/join", bootstrap.room_id);
     let join_body = serde_json::json!({ "name": "guest" });
     let response = app
+        .clone()
         .oneshot(
             axum::http::Request::builder()
                 .method(axum::http::Method::POST)
@@ -46,6 +47,7 @@ async fn create_and_join_room() {
     assert_eq!(response.status(), axum::http::StatusCode::OK);
 
     let status_resp = app
+        .clone()
         .oneshot(
             axum::http::Request::builder()
                 .method(axum::http::Method::GET)
@@ -56,7 +58,9 @@ async fn create_and_join_room() {
         .await
         .unwrap();
     assert_eq!(status_resp.status(), axum::http::StatusCode::OK);
-    let body_bytes = hyper::body::to_bytes(status_resp.into_body()).await.unwrap();
+    let body_bytes = hyper::body::to_bytes(status_resp.into_body())
+        .await
+        .unwrap();
     let status: server::matchmaker::StatusResponse = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(status.server_pv, SERVER_PV);
     assert_eq!(status.regions.len(), 1);

--- a/tests/e2e_matchmaking.rs
+++ b/tests/e2e_matchmaking.rs
@@ -28,7 +28,7 @@ async fn create_and_join_room() {
     let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
     let bootstrap: server::matchmaker::CreateRoomResponse =
         serde_json::from_slice(&body_bytes).unwrap();
-    assert_eq!(bootstrap.seed.as_u64() > 0, true);
+    assert!(bootstrap.seed.as_u64() > 0);
 
     let join_uri = format!("/v1/rooms/{}/join", bootstrap.room_id);
     let join_body = serde_json::json!({ "name": "guest" });

--- a/tests/e2e_ws_roundtrip.rs
+++ b/tests/e2e_ws_roundtrip.rs
@@ -1,4 +1,3 @@
-use axum::extract::ws::WebSocketUpgrade;
 use server::{config::Config, http};
 use tower::ServiceExt;
 

--- a/tests/network_spec.rs
+++ b/tests/network_spec.rs
@@ -1,0 +1,584 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::http::{self as axum_http, header};
+use axum::response::Response;
+use axum::Router;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use server::config::Config;
+use server::errors::ErrorCode;
+use server::http::{self, HttpState};
+use server::protocol::{self, OutboundMessage, SERVER_PV};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tower::ServiceExt;
+
+async fn spawn_http_server(mut config: Config) -> (HttpState, SocketAddr, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    config.bind_address = addr.to_string();
+    config.ws_url = format!("ws://{}/v1/ws", addr);
+
+    let state = HttpState::new(config);
+    let router: Router = http::router(state.clone());
+
+    let std_listener = listener.into_std().unwrap();
+    std_listener.set_nonblocking(true).unwrap();
+    let server = axum::Server::from_tcp(std_listener)
+        .unwrap()
+        .serve(router.into_make_service());
+    let handle = tokio::spawn(async move {
+        if let Err(err) = server.await {
+            panic!("server error: {err}");
+        }
+    });
+
+    // Give the server a moment to come online before returning.
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    (state, addr, handle)
+}
+
+fn build_request<B>(req: axum_http::Request<B>) -> axum_http::Request<B> {
+    req
+}
+
+async fn response_json(response: Response) -> serde_json::Value {
+    let status = response.status();
+    assert!(status.is_success(), "unexpected status: {status}");
+    let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn rest_create_room_validates_inputs() {
+    let config = Config::default();
+    let state = HttpState::new(config.clone());
+    let app = http::router(state.clone());
+
+    // Invalid region should surface INVALID_STATE as per spec §5.1.
+    let bad_region = json!({
+        "name": "host",
+        "region": "us-west-2",
+        "maxPlayers": 4,
+        "mode": "endless"
+    });
+    let response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri("/v1/rooms")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(bad_region.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::BAD_REQUEST);
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["code"].as_str(), Some("INVALID_STATE"));
+
+    // Zero maxPlayers should be rejected.
+    let zero_capacity = json!({
+        "name": "host",
+        "region": config.region,
+        "maxPlayers": 0,
+        "mode": "endless"
+    });
+    let response = app
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri("/v1/rooms")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(zero_capacity.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::BAD_REQUEST);
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["code"].as_str(), Some("INVALID_STATE"));
+}
+
+#[tokio::test]
+async fn rest_join_room_enforces_capacity_and_name_rules() {
+    let mut config = Config::default();
+    config.room_capacity = 2;
+    let state = HttpState::new(config.clone());
+    let app = http::router(state.clone());
+
+    let create_body = json!({
+        "name": "host",
+        "region": config.region,
+        "maxPlayers": 1,
+        "mode": "endless"
+    });
+    let create_response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri("/v1/rooms")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(create_body.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), axum_http::StatusCode::CREATED);
+    let body = hyper::body::to_bytes(create_response.into_body())
+        .await
+        .unwrap();
+    let bootstrap: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let room_id = bootstrap["roomId"].as_str().unwrap().to_string();
+
+    // Room should be full because host occupies the only slot.
+    let join_uri = format!("/v1/rooms/{}/join", room_id);
+    let join_body = json!({ "name": "guest" });
+    let response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri(&join_uri)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(join_body.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::CONFLICT);
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["code"].as_str(), Some("ROOM_FULL"));
+
+    // Create a room with free capacity to test NAME_TAKEN handling.
+    let create_body = json!({
+        "name": "host",
+        "region": config.region,
+        "maxPlayers": 2,
+        "mode": "endless"
+    });
+    let create_response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri("/v1/rooms")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(create_body.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), axum_http::StatusCode::CREATED);
+    let body = hyper::body::to_bytes(create_response.into_body())
+        .await
+        .unwrap();
+    let bootstrap: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let join_uri = format!("/v1/rooms/{}/join", bootstrap["roomId"].as_str().unwrap());
+    let duplicate = json!({ "name": "host" });
+    let response = app
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri(&join_uri)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(duplicate.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::CONFLICT);
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["code"].as_str(), Some("NAME_TAKEN"));
+}
+
+#[tokio::test]
+async fn rest_leave_room_requires_valid_token() {
+    let config = Config::default();
+    let state = HttpState::new(config.clone());
+    let app = http::router(state.clone());
+
+    let create_body = json!({
+        "name": "host",
+        "region": config.region,
+        "maxPlayers": 2,
+        "mode": "endless"
+    });
+    let response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri("/v1/rooms")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(create_body.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let bootstrap: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let room_id = bootstrap["roomId"].as_str().unwrap().to_string();
+
+    // Join as second player to obtain a token.
+    let join_uri = format!("/v1/rooms/{}/join", room_id);
+    let join_body = json!({ "name": "guest" });
+    let response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri(&join_uri)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(join_body.to_string()))
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let guest_bootstrap: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let guest_token = guest_bootstrap["wsToken"].as_str().unwrap().to_string();
+
+    // Attempt to leave with a token from a different room should fail.
+    let other_room = state
+        .matchmaker
+        .create_room(server::matchmaker::CreateRoomRequest {
+            name: "other".to_string(),
+            region: config.region.clone(),
+            max_players: 2,
+            mode: "endless".to_string(),
+        })
+        .await
+        .unwrap();
+    let leave_uri = format!("/v1/rooms/{}/leave", room_id);
+    let response = app
+        .clone()
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri(&leave_uri)
+                .header(
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", other_room.ws_token),
+                )
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::UNAUTHORIZED);
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["code"].as_str(), Some("UNAUTHORIZED"));
+
+    // Leaving with the correct token should succeed and return 204.
+    let response = app
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::POST)
+                .uri(&leave_uri)
+                .header(header::AUTHORIZATION, format!("Bearer {}", guest_token))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn rest_status_reports_region_and_version() {
+    let config = Config::default();
+    let state = HttpState::new(config.clone());
+    let app = http::router(state);
+
+    let response = app
+        .oneshot(build_request(
+            axum_http::Request::builder()
+                .method(axum_http::Method::GET)
+                .uri("/v1/status")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum_http::StatusCode::OK);
+    let status = response_json(response).await;
+    assert_eq!(status["serverPv"].as_u64(), Some(SERVER_PV as u64));
+    assert_eq!(status["regions"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        status["regions"][0]["id"].as_str(),
+        Some(config.region.as_str())
+    );
+    assert_eq!(
+        status["regions"][0]["wsUrl"].as_str(),
+        Some(config.ws_url.as_str())
+    );
+}
+
+#[tokio::test]
+async fn websocket_join_sequence_matches_spec() {
+    let (state, addr, server_handle) = spawn_http_server(Config::default()).await;
+
+    let bootstrap = state
+        .matchmaker
+        .create_room(server::matchmaker::CreateRoomRequest {
+            name: "host".to_string(),
+            region: state.config.region.clone(),
+            max_players: 2,
+            mode: "endless".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let url = url::Url::parse(&format!("ws://{addr}/v1/ws?token={}", bootstrap.ws_token)).unwrap();
+    let (mut socket, _response) = tokio_tungstenite::connect_async(url).await.unwrap();
+
+    let join = json!({
+        "type": "join",
+        "pv": SERVER_PV,
+        "seq": 1,
+        "ts": 0,
+        "payload": {
+            "name": "host",
+            "clientVersion": "android-0.1.0",
+            "device": "Pixel_6_Pro",
+            "capabilities": {"tilt": true, "vibrate": true}
+        }
+    });
+    socket.send(Message::Text(join.to_string())).await.unwrap();
+
+    let welcome = expect_outbound(&mut socket, "welcome").await;
+    let (player_id, resume_token) = match welcome {
+        OutboundMessage::Welcome { payload, .. } => {
+            assert_eq!(payload.room_id, bootstrap.room_id);
+            assert_eq!(payload.cfg.tps, state.config.tick_rate_hz);
+            assert_eq!(payload.cfg.snapshot_rate_hz, state.config.snapshot_rate_hz);
+            (payload.player_id.clone(), payload.resume_token.clone())
+        }
+        other => panic!("expected welcome, got {other:?}"),
+    };
+
+    let start = expect_outbound(&mut socket, "start").await;
+    if let OutboundMessage::Start { payload, .. } = start {
+        assert_eq!(payload.tps, state.config.tick_rate_hz);
+    } else {
+        panic!("expected start frame");
+    }
+
+    let snapshot = expect_outbound(&mut socket, "snapshot").await;
+    if let OutboundMessage::Snapshot { payload, .. } = snapshot {
+        assert!(payload.full, "first snapshot should be full");
+        assert_eq!(payload.stats.dropped_snapshots, 0);
+        assert_eq!(payload.players[0].id, player_id.clone());
+    } else {
+        panic!("expected snapshot frame");
+    }
+
+    // Ping/pong per §6 should echo timing information.
+    let ping = json!({
+        "type": "ping",
+        "pv": SERVER_PV,
+        "seq": 2,
+        "ts": 0,
+        "payload": {"t0": 1234567890u64}
+    });
+    socket.send(Message::Text(ping.to_string())).await.unwrap();
+    let pong = expect_outbound(&mut socket, "pong").await;
+    if let OutboundMessage::Pong { payload, .. } = pong {
+        assert_eq!(payload.t0, 1234567890);
+        assert!(payload.t1 >= payload.t0);
+    } else {
+        panic!("expected pong frame");
+    }
+
+    // Valid reconnect should return a snapshot with a resume event.
+    let reconnect = json!({
+        "type": "reconnect",
+        "pv": SERVER_PV,
+        "seq": 3,
+        "ts": 0,
+        "payload": {
+            "playerId": player_id,
+            "resumeToken": resume_token,
+            "lastAckTick": 0
+        }
+    });
+    socket
+        .send(Message::Text(reconnect.to_string()))
+        .await
+        .unwrap();
+    let _resume_snapshot = expect_snapshot_with_event(&mut socket, "resume").await;
+
+    // Invalid resume token should raise an UNAUTHORIZED error.
+    let bad_reconnect = json!({
+        "type": "reconnect",
+        "pv": SERVER_PV,
+        "seq": 4,
+        "ts": 0,
+        "payload": {
+            "playerId": "p_wrong",
+            "resumeToken": "not-valid",
+            "lastAckTick": 0
+        }
+    });
+    socket
+        .send(Message::Text(bad_reconnect.to_string()))
+        .await
+        .unwrap();
+    let error = expect_outbound(&mut socket, "error").await;
+    if let OutboundMessage::Error { payload, .. } = error {
+        assert_eq!(payload.code, ErrorCode::Unauthorized);
+    } else {
+        panic!("expected error frame");
+    }
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_rejects_out_of_order_messages() {
+    let (state, addr, server_handle) = spawn_http_server(Config::default()).await;
+
+    let bootstrap = state
+        .matchmaker
+        .create_room(server::matchmaker::CreateRoomRequest {
+            name: "host".to_string(),
+            region: state.config.region.clone(),
+            max_players: 2,
+            mode: "endless".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let join_resp = state
+        .matchmaker
+        .join_room(
+            &bootstrap.room_id,
+            server::matchmaker::JoinRoomRequest {
+                name: "guest".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let url = url::Url::parse(&format!("ws://{addr}/v1/ws?token={}", join_resp.ws_token)).unwrap();
+    let (mut socket, _response) = tokio_tungstenite::connect_async(url).await.unwrap();
+
+    // Sending an input before join should yield INVALID_STATE.
+    let input = json!({
+        "type": "input",
+        "pv": SERVER_PV,
+        "seq": 1,
+        "ts": 0,
+        "payload": {
+            "tick": 10,
+            "axisX": 0.1,
+            "jump": false
+        }
+    });
+    socket.send(Message::Text(input.to_string())).await.unwrap();
+    let error = expect_outbound(&mut socket, "error").await;
+    if let OutboundMessage::Error { payload, .. } = error {
+        assert_eq!(payload.code, ErrorCode::InvalidState);
+    } else {
+        panic!("expected error frame");
+    }
+
+    // Mismatched protocol version should raise BAD_VERSION and close the socket.
+    let join = json!({
+        "type": "join",
+        "pv": SERVER_PV - 1,
+        "seq": 2,
+        "ts": 0,
+        "payload": {
+            "name": "guest",
+            "clientVersion": "android-0.1.0"
+        }
+    });
+    socket.send(Message::Text(join.to_string())).await.unwrap();
+    let error = expect_outbound(&mut socket, "error").await;
+    if let OutboundMessage::Error { payload, .. } = error {
+        assert_eq!(payload.code, ErrorCode::BadVersion);
+    } else {
+        panic!("expected error frame");
+    }
+
+    // Subsequent messages should not be delivered after BAD_VERSION.
+    let maybe_frame = timeout(Duration::from_millis(200), socket.next())
+        .await
+        .unwrap();
+    match maybe_frame {
+        None => {}
+        Some(Ok(Message::Close(_))) => {}
+        Some(Err(_)) => {}
+        Some(Ok(other)) => panic!("unexpected frame after BAD_VERSION: {other:?}"),
+    }
+
+    server_handle.abort();
+}
+
+async fn expect_outbound(
+    socket: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+    expected_type: &str,
+) -> OutboundMessage {
+    loop {
+        let frame = timeout(Duration::from_secs(2), socket.next())
+            .await
+            .expect("receive timeout")
+            .expect("websocket closed");
+        match frame {
+            Ok(Message::Text(text)) => {
+                let outbound: OutboundMessage = serde_json::from_str(&text).unwrap();
+                if outbound_name(&outbound) == expected_type {
+                    return outbound;
+                }
+            }
+            Ok(Message::Binary(_)) => panic!("unexpected binary frame"),
+            Ok(Message::Close(_)) => panic!("socket closed unexpectedly"),
+            Ok(Message::Ping(payload)) => {
+                socket.send(Message::Pong(payload)).await.unwrap();
+            }
+            Ok(Message::Pong(_)) => {}
+            Ok(Message::Frame(_)) => {}
+            Err(err) => panic!("websocket error: {err}"),
+        }
+    }
+}
+
+fn outbound_name(message: &OutboundMessage) -> &'static str {
+    match message {
+        OutboundMessage::Welcome { .. } => "welcome",
+        OutboundMessage::Start { .. } => "start",
+        OutboundMessage::Snapshot { .. } => "snapshot",
+        OutboundMessage::Pong { .. } => "pong",
+        OutboundMessage::Error { .. } => "error",
+        OutboundMessage::Finish { .. } => "finish",
+        OutboundMessage::PlayerPresence { .. } => "player_presence",
+    }
+}
+
+async fn expect_snapshot_with_event(
+    socket: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+    kind: &str,
+) -> protocol::SnapshotPayload {
+    loop {
+        let outbound = expect_outbound(socket, "snapshot").await;
+        if let OutboundMessage::Snapshot { payload, .. } = outbound {
+            if payload.events.iter().any(|event| event.kind == kind) {
+                return payload;
+            }
+        }
+    }
+}

--- a/tests/network_spec.rs
+++ b/tests/network_spec.rs
@@ -110,8 +110,10 @@ async fn rest_create_room_validates_inputs() {
 
 #[tokio::test]
 async fn rest_join_room_enforces_capacity_and_name_rules() {
-    let mut config = Config::default();
-    config.room_capacity = 2;
+    let config = Config {
+        room_capacity: 2,
+        ..Config::default()
+    };
     let state = HttpState::new(config.clone());
     let app = http::router(state.clone());
 


### PR DESCRIPTION
## Summary
- add comprehensive network_spec integration tests covering REST flows, WebSocket lifecycle, reconnects, and protocol errors
- enable running all integration tests via explicit [[test]] targets and add missing deserializers for matchmaker responses
- update existing tests to align with current room snapshot API and clean up unused imports

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d4d4e51984832daf54fea2219c969c