### PR TITLE
Fix clippy warning in network spec test

### DIFF
--- a/tests/network_spec.rs
+++ b/tests/network_spec.rs
@@ -110,8 +110,10 @@ async fn rest_create_room_validates_inputs() {
 
 #[tokio::test]
 async fn rest_join_room_enforces_capacity_and_name_rules() {
-    let mut config = Config::default();
-    config.room_capacity = 2;
+    let config = Config {
+        room_capacity: 2,
+        ..Config::default()
+    };
     let state = HttpState::new(config.clone());
     let app = http::router(state.clone());
 


### PR DESCRIPTION
## Summary
- initialize the test configuration with a struct literal to set room capacity without post-assignment

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d4ece3d980832da53e9092981579ca