### PR TITLE
Fix clippy warnings for server frames and config

### DIFF
--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -359,7 +359,7 @@ impl Lobby {
         let seq = room.next_seq();
         let state = room.lobby_state();
         let frame = ServerFrame::LobbyState {
-            meta: Envelope::new("lobby_state", seq, state),
+            meta: Envelope::boxed("lobby_state", seq, state),
         };
         let sim = room.sim.clone();
         let player_id = player.id.clone();
@@ -381,7 +381,7 @@ impl Lobby {
                     if let Some(new_master_id) = room.transfer_master() {
                         let seq = room.next_seq();
                         frames.push(ServerFrame::RoleChanged {
-                            meta: Envelope::new(
+                            meta: Envelope::boxed(
                                 "role_changed",
                                 seq,
                                 RoleChangedPayload {
@@ -393,7 +393,7 @@ impl Lobby {
                 }
                 let seq = room.next_seq();
                 frames.push(ServerFrame::LobbyState {
-                    meta: Envelope::new("lobby_state", seq, room.lobby_state()),
+                    meta: Envelope::boxed("lobby_state", seq, room.lobby_state()),
                 });
                 for frame in frames.clone() {
                     room.broadcast(frame).await;
@@ -426,7 +426,7 @@ impl Lobby {
         let state = room.lobby_state();
         let seq = room.next_seq();
         let frame = ServerFrame::LobbyState {
-            meta: Envelope::new("lobby_state", seq, state.clone()),
+            meta: Envelope::boxed("lobby_state", seq, state.clone()),
         };
         room.broadcast(frame).await;
         Ok(state)
@@ -456,7 +456,7 @@ impl Lobby {
         let payload = room.start_countdown(countdown_sec)?;
         let seq = room.next_seq();
         let frame = ServerFrame::StartCountdown {
-            meta: Envelope::new("start_countdown", seq, payload.clone()),
+            meta: Envelope::boxed("start_countdown", seq, payload.clone()),
         };
         let sim = room.sim.clone();
         let start_at = payload.start_at_ms;
@@ -472,7 +472,7 @@ impl Lobby {
                 let start_payload = guard.set_running();
                 let seq = guard.next_seq();
                 let frame = ServerFrame::Start {
-                    meta: Envelope::new("start", seq, start_payload.clone()),
+                    meta: Envelope::boxed("start", seq, start_payload.clone()),
                 };
                 guard.broadcast(frame).await;
                 drop(guard);
@@ -519,11 +519,11 @@ impl Lobby {
         let lobby_state = room.lobby_state();
         let lobby_seq = room.next_seq();
         let lobby_frame = ServerFrame::LobbyState {
-            meta: Envelope::new("lobby_state", lobby_seq, lobby_state),
+            meta: Envelope::boxed("lobby_state", lobby_seq, lobby_state),
         };
         Ok(AttachResult {
             welcome: ServerFrame::Welcome {
-                meta: Envelope::new("welcome", seq, payload),
+                meta: Envelope::boxed("welcome", seq, payload),
             },
             lobby: lobby_frame,
             sim: room.sim.clone(),

--- a/server/src/proto.rs
+++ b/server/src/proto.rs
@@ -27,6 +27,10 @@ impl<T> Envelope<T> {
             payload,
         }
     }
+
+    pub fn boxed(kind: impl Into<String>, seq: u64, payload: T) -> Box<Self> {
+        Box::new(Self::new(kind, seq, payload))
+    }
 }
 
 pub fn env<T: DeserializeOwned>(text: &str) -> Result<Envelope<T>, WireError> {
@@ -314,43 +318,43 @@ pub struct FinishPayload {
 pub enum ServerFrame {
     Welcome {
         #[serde(flatten)]
-        meta: Envelope<WelcomePayload>,
+        meta: Box<Envelope<WelcomePayload>>,
     },
     LobbyState {
         #[serde(flatten)]
-        meta: Envelope<LobbyState>,
+        meta: Box<Envelope<LobbyState>>,
     },
     StartCountdown {
         #[serde(flatten)]
-        meta: Envelope<StartCountdownPayload>,
+        meta: Box<Envelope<StartCountdownPayload>>,
     },
     Start {
         #[serde(flatten)]
-        meta: Envelope<StartPayload>,
+        meta: Box<Envelope<StartPayload>>,
     },
     Snapshot {
         #[serde(flatten)]
-        meta: Envelope<SnapshotPayload>,
+        meta: Box<Envelope<SnapshotPayload>>,
     },
     RoleChanged {
         #[serde(flatten)]
-        meta: Envelope<RoleChangedPayload>,
+        meta: Box<Envelope<RoleChangedPayload>>,
     },
     Pong {
         #[serde(flatten)]
-        meta: Envelope<PongPayload>,
+        meta: Box<Envelope<PongPayload>>,
     },
     PlayerPresence {
         #[serde(flatten)]
-        meta: Envelope<PlayerPresencePayload>,
+        meta: Box<Envelope<PlayerPresencePayload>>,
     },
     Finish {
         #[serde(flatten)]
-        meta: Envelope<FinishPayload>,
+        meta: Box<Envelope<FinishPayload>>,
     },
     Error {
         #[serde(flatten)]
-        meta: Envelope<WireError>,
+        meta: Box<Envelope<WireError>>,
     },
 }
 

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -196,7 +196,7 @@ async fn sim_loop(_room_id: String, mut rx: mpsc::Receiver<SimCommand>) {
                             stats: SnapshotStats { dropped_snapshots: 0 },
                         };
                         let frame = ServerFrame::Snapshot {
-                            meta: Envelope::new("snapshot", seq, payload),
+                            meta: Envelope::boxed("snapshot", seq, payload),
                         };
                         room_guard.broadcast(frame).await;
                     }

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -51,9 +51,11 @@ impl WsServer {
 async fn handle_socket(stream: tokio::net::TcpStream, state: Arc<HttpState>) -> anyhow::Result<()> {
     let holder = Arc::new(Mutex::new(None));
     let callback_holder = holder.clone();
-    let mut config = WebSocketConfig::default();
-    config.max_message_size = Some(4 * 1024);
-    config.max_frame_size = Some(4 * 1024);
+    let config = WebSocketConfig {
+        max_message_size: Some(4 * 1024),
+        max_frame_size: Some(4 * 1024),
+        ..Default::default()
+    };
     let ws_stream = accept_hdr_async_with_config(
         stream,
         {
@@ -223,7 +225,7 @@ async fn handle_socket(stream: tokio::net::TcpStream, state: Arc<HttpState>) -> 
                     t1: util::now_ms(),
                 };
                 let frame = ServerFrame::Pong {
-                    meta: Envelope::new("pong", seq, payload),
+                    meta: Envelope::boxed("pong", seq, payload),
                 };
                 queue.push(frame).await;
             }
@@ -443,7 +445,7 @@ async fn send_error(
     let seq = next_seq(state, room_id).await;
     let payload = WireError::new(code, message);
     let frame = ServerFrame::Error {
-        meta: Envelope::new("error", seq, payload),
+        meta: Envelope::boxed("error", seq, payload),
     };
     queue.push(frame).await;
 }
@@ -457,7 +459,7 @@ async fn send_app_error(
     let seq = next_seq(state, room_id).await;
     let payload = err.wire();
     let frame = ServerFrame::Error {
-        meta: Envelope::new("error", seq, payload),
+        meta: Envelope::boxed("error", seq, payload),
     };
     queue.push(frame).await;
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -24,13 +24,15 @@ async fn spawn_server() -> (Config, oneshot::Sender<()>, tokio::task::JoinHandle
         .try_init();
     let api_port = find_port().await;
     let ws_port = find_port().await;
-    let mut config = Config::default();
-    config.api_port = api_port;
-    config.ws_port = ws_port;
-    config.api_bind = format!("127.0.0.1:{api_port}");
-    config.ws_bind = format!("127.0.0.1:{ws_port}");
-    config.jwt_secret = "test-secret".into();
-    config.enable_permessage_deflate = false;
+    let config = Config {
+        api_port,
+        ws_port,
+        api_bind: format!("127.0.0.1:{api_port}"),
+        ws_bind: format!("127.0.0.1:{ws_port}"),
+        jwt_secret: "test-secret".into(),
+        enable_permessage_deflate: false,
+        ..Config::default()
+    };
     let state = Arc::new(http::HttpState::new(config.clone()));
     let router = http::router(state.clone());
 


### PR DESCRIPTION
## Summary
- box large server frame envelopes and provide a helper for boxed envelopes to satisfy clippy::large-enum-variant
- update all frame construction sites to use the boxed helper and clean up websocket config initialization
- build integration test configuration without mutating a Default value to appease clippy

## Testing
- cargo clippy --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d53f3dfe90832dafb989a71cff11b4