### PR TITLE
Add lobby character selection flow

### DIFF
--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -45,6 +45,7 @@ pub struct Player {
     pub name: String,
     pub role: Role,
     pub ready: bool,
+    pub character_id: Option<String>,
     pub queue: Option<ConnectionQueue>,
     pub last_ack_tick: u64,
     pub last_input_seq: u64,
@@ -59,6 +60,7 @@ impl Player {
             name,
             role,
             ready: false,
+            character_id: None,
             queue: None,
             last_ack_tick: 0,
             last_input_seq: 0,
@@ -133,6 +135,7 @@ impl Room {
                     name: p.name.clone(),
                     role: p.role.as_str().to_string(),
                     ready: p.ready,
+                    character_id: p.character_id.clone(),
                 })
                 .collect(),
             max_players: self.max_players,
@@ -202,6 +205,27 @@ impl Room {
             ));
         };
         player.ready = ready;
+        Ok(())
+    }
+
+    pub fn set_character(
+        &mut self,
+        player_id: &str,
+        character_id: Option<String>,
+    ) -> Result<(), AppError> {
+        if !matches!(self.state, RoomState::Lobby) {
+            return Err(AppError::http(
+                ErrorCode::RoomStateInvalid,
+                "cannot change character now",
+            ));
+        }
+        let Some(player) = self.find_player_mut(player_id) else {
+            return Err(AppError::http(
+                ErrorCode::Unauthorized,
+                "player not in room",
+            ));
+        };
+        player.character_id = character_id;
         Ok(())
     }
 
@@ -423,6 +447,29 @@ impl Lobby {
         };
         let mut room = room_arc.write().await;
         room.set_ready(player_id, ready)?;
+        let state = room.lobby_state();
+        let seq = room.next_seq();
+        let frame = ServerFrame::LobbyState {
+            meta: Envelope::boxed("lobby_state", seq, state.clone()),
+        };
+        room.broadcast(frame).await;
+        Ok(state)
+    }
+
+    pub async fn set_character(
+        &self,
+        room_id: &str,
+        player_id: &str,
+        character_id: Option<String>,
+    ) -> Result<LobbyState, AppError> {
+        let Some(room_arc) = self.room(room_id).await else {
+            return Err(AppError::http(
+                ErrorCode::RoomStateInvalid,
+                "room not found",
+            ));
+        };
+        let mut room = room_arc.write().await;
+        room.set_character(player_id, character_id)?;
         let state = room.lobby_state();
         let seq = room.next_seq();
         let frame = ServerFrame::LobbyState {

--- a/server/src/proto.rs
+++ b/server/src/proto.rs
@@ -127,6 +127,13 @@ pub struct ClientStartRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ClientCharacterSelect {
+    #[serde(default)]
+    pub character_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClientFrame {
     Join {
@@ -157,6 +164,10 @@ pub enum ClientFrame {
         #[serde(flatten)]
         meta: Envelope<ClientStartRequest>,
     },
+    CharacterSelect {
+        #[serde(flatten)]
+        meta: Envelope<ClientCharacterSelect>,
+    },
 }
 
 impl ClientFrame {
@@ -169,6 +180,7 @@ impl ClientFrame {
             ClientFrame::Reconnect { meta } => meta.seq,
             ClientFrame::ReadySet { meta } => meta.seq,
             ClientFrame::StartRequest { meta } => meta.seq,
+            ClientFrame::CharacterSelect { meta } => meta.seq,
         }
     }
 
@@ -181,6 +193,7 @@ impl ClientFrame {
             ClientFrame::Reconnect { .. } => "reconnect",
             ClientFrame::ReadySet { .. } => "ready_set",
             ClientFrame::StartRequest { .. } => "start_request",
+            ClientFrame::CharacterSelect { .. } => "character_select",
         }
     }
 }
@@ -226,6 +239,8 @@ pub struct LobbyPlayer {
     pub role: String,
     #[serde(default)]
     pub ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub character_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -3,8 +3,9 @@ use crate::{
     errors::{AppError, ErrorCode, WireError},
     http::HttpState,
     proto::{
-        ClientInput, ClientInputBatch, ClientJoin, ClientPing, ClientReadySet, ClientReconnect,
-        ClientStartRequest, Envelope, PongPayload, ServerFrame, PROTOCOL_VERSION,
+        ClientCharacterSelect, ClientInput, ClientInputBatch, ClientJoin, ClientPing,
+        ClientReadySet, ClientReconnect, ClientStartRequest, Envelope, PongPayload, ServerFrame,
+        PROTOCOL_VERSION,
     },
     util,
 };
@@ -377,6 +378,30 @@ async fn handle_socket(stream: tokio::net::TcpStream, state: Arc<HttpState>) -> 
                         countdown,
                         state.config.require_ready,
                     )
+                    .await
+                {
+                    send_app_error(&state, &claims.room_id, &queue, err).await;
+                }
+            }
+            "character_select" => {
+                let payload: ClientCharacterSelect =
+                    match serde_json::from_value(raw_env.payload.clone()) {
+                        Ok(p) => p,
+                        Err(err) => {
+                            send_error(
+                                &state,
+                                &claims.room_id,
+                                &queue,
+                                ErrorCode::InvalidState,
+                                err.to_string(),
+                            )
+                            .await;
+                            continue;
+                        }
+                    };
+                if let Err(err) = state
+                    .lobby
+                    .set_character(&claims.room_id, &claims.player_id, payload.character_id)
                     .await
                 {
                     send_app_error(&state, &claims.room_id, &queue, err).await;

--- a/tests/lobby.rs
+++ b/tests/lobby.rs
@@ -6,6 +6,43 @@ fn test_sim() -> SimHandle {
 }
 
 #[tokio::test]
+async fn character_selection_updates_lobby_state() {
+    let lobby = Lobby::new();
+    let room_id = "room-select".to_string();
+    let sim = test_sim();
+    let master = Player::new("p1".into(), "host".into(), Role::Master);
+    lobby
+        .create_room(
+            room_id.clone(),
+            "seed".into(),
+            "region".into(),
+            4,
+            master,
+            sim.clone(),
+        )
+        .await;
+
+    lobby
+        .join_room(
+            &room_id,
+            Player::new("p2".into(), "guest".into(), Role::Member),
+        )
+        .await
+        .unwrap();
+
+    let state = lobby
+        .set_character(&room_id, "p2", Some("warrior".into()))
+        .await
+        .expect("character should update");
+    let guest = state
+        .players
+        .into_iter()
+        .find(|p| p.id == "p2")
+        .expect("guest present");
+    assert_eq!(guest.character_id.as_deref(), Some("warrior"));
+}
+
+#[tokio::test]
 async fn master_transfer_promotes_earliest_member() {
     let lobby = Lobby::new();
     let room_id = "room-a".to_string();


### PR DESCRIPTION
## Summary
- add lobby character selection support to the realtime protocol, including new `character_select` frame handling
- extend lobby/player payloads with optional `characterId` propagation and gate changes to the lobby state
- cover the behaviour with a unit test exercising character selection updates

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d54fb2a158832da394cb12c4911096