### PR TITLE
Improve Docker image build and publishing pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+.dockerignore
+.target
+target
+**/target
+**/*.rs.bk
+**/*.log
+NETWORK_PROTOCOL.md
+README.md
+tests/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PUSH_IMAGE: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      IMAGE_NAME: ${{ github.event.repository.name }}
     permissions:
       contents: read
       packages: write
@@ -50,3 +51,24 @@ jobs:
           push: ${{ env.PUSH_IMAGE == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Ensure GHCR package is public
+        if: env.PUSH_IMAGE == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          if gh api "orgs/${OWNER}" > /dev/null 2>&1; then
+            scope="orgs/${OWNER}"
+          else
+            scope="users/${OWNER}"
+          fi
+          gh api \
+            --method PATCH \
+            "${scope}/packages/container/${PACKAGE_NAME}/visibility" \
+            -f visibility=public \
+            || echo "Package visibility update skipped (package may already be public)."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,34 @@
-FROM rust:1.79-slim as builder
+# syntax=docker/dockerfile:1.6
+
+FROM rust:1.79-slim AS builder
+
 WORKDIR /app
-COPY . .
-RUN cargo build --release -p server
+
+# Install build tooling that is not bundled with the slim image
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y ca-certificates binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-fetch dependencies so Docker can cache them between builds
+COPY Cargo.toml Cargo.lock ./
+COPY server/Cargo.toml server/Cargo.toml
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo fetch -p server --locked
+
+# Copy the actual source last so dependency layers stay cached
+COPY server ./server
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p server --locked \
+    && strip target/release/server
 
 FROM gcr.io/distroless/cc-debian12
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/target/release/server /usr/local/bin/server
-CMD ["/usr/local/bin/server"]
+
+USER nonroot
+
+ENTRYPOINT ["/usr/local/bin/server"]


### PR DESCRIPTION
## Summary
- optimize the multi-stage Docker build by caching dependencies, stripping the final binary, and running the server as a non-root user
- add a .dockerignore to reduce the Docker build context size
- enhance the publishing workflow with Buildx cache reuse and an automated step to make the GHCR package public

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d554ef66bc832d90865fae4bd888f3