### PR TITLE
Fix cargo fetch command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY server/Cargo.toml server/Cargo.toml
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo fetch -p server --locked
+    cargo fetch --locked --manifest-path server/Cargo.toml
 
 # Copy the actual source last so dependency layers stay cached
 COPY server ./server


### PR DESCRIPTION
## Summary
- update the Dockerfile to use `cargo fetch --manifest-path server/Cargo.toml`

## Testing
- docker build . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55d8e1458832da25b9a501da0a322