### PR TITLE
Broadcast full roster in snapshots

### DIFF
--- a/NETWORK_PROTOCOL.md
+++ b/NETWORK_PROTOCOL.md
@@ -510,7 +510,7 @@ Frequency: 20–30 Hz; server accepts `tick` in window `[currentTick - maxRollba
 ```json
 {"type":"lobby_state","pv":1,"seq":50,"ts":1737766,"payload":{"roomState":"lobby","players":[{"id":"p1","name":"bene","ready":true,"role":"master"},{"id":"p2","name":"ally","ready":true,"role":"member"}]}}
 {"type":"start_countdown","pv":1,"seq":60,"ts":1737767,"payload":{"startAtMs":1737765123456,"serverTick":12000,"countdownSec":3}}
-{"type":"start","pv":1,"seq":61,"ts":1737767,"payload":{"startTick":300,"serverTick":12042,"serverTimeMs":1737765123456,"tps":60}}
+{"type":"start","pv":1,"seq":61,"ts":1737767,"payload":{"startTick":300,"serverTick":12042,"serverTimeMs":1737765123456,"tps":60,"players":[{"id":"p1","name":"bene","role":"master","ready":true,"characterId":"aurora"},{"id":"p2","name":"ally","role":"member","ready":true,"characterId":"cobalt"}]}}
 ```
 
 ---
@@ -534,6 +534,7 @@ Frequency: 20–30 Hz; server accepts `tick` in window `[currentTick - maxRollba
   * Added **Room Master + Lobby** flow (REST `/start`, optional WS `start_request`).
   * New S2C: `lobby_state`, `start_countdown`, `role_changed`; `welcome` extended with `role`, `roomState`, `lobby`.
   * New C2S: `character_select`; lobby players now advertise optional `characterId`.
+  * `start` frames include the full lobby roster (id, name, role, ready, `characterId`).
   * Added errors: `NOT_MASTER`, `ROOM_STATE_INVALID`, `ROOM_NOT_READY`, `START_ALREADY`, `COUNTDOWN_ACTIVE`.
   * Clarified local `ws://`/`http://` allowances; compression “recommended” vs “required”.
 
@@ -607,7 +608,13 @@ interface S2C_LobbyState {
   maxPlayers?: number;
 }
 interface S2C_StartCountdown { startAtMs: number; serverTick: number; countdownSec: number; }
-interface S2C_Start { startTick: number; serverTick: number; serverTimeMs: number; tps: number; }
+interface S2C_Start {
+  startTick: number;
+  serverTick: number;
+  serverTimeMs: number;
+  tps: number;
+  players: LobbyPlayer[];
+}
 
 interface NetPlayer { id: string; x: number; y: number; vx: number; vy: number; alive: boolean; }
 type NetEvent = { kind: "spring" | "break"; x: number; y: number; tick: number; };

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -284,11 +284,23 @@ impl Room {
 
     pub fn set_running(&mut self) -> StartPayload {
         self.state = RoomState::Running { start_tick: 0 };
+        let players = self
+            .players
+            .iter()
+            .map(|p| LobbyPlayer {
+                id: p.id.clone(),
+                name: p.name.clone(),
+                role: p.role.as_str().to_string(),
+                ready: p.ready,
+                character_id: p.character_id.clone(),
+            })
+            .collect();
         StartPayload {
             start_tick: 0,
             server_tick: 0,
             server_time_ms: util::now_ms(),
             tps: 60,
+            players,
         }
     }
 

--- a/server/src/proto.rs
+++ b/server/src/proto.rs
@@ -258,6 +258,7 @@ pub struct StartPayload {
     pub server_tick: u64,
     pub server_time_ms: u64,
     pub tps: u64,
+    pub players: Vec<LobbyPlayer>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/server/src/sim.rs
+++ b/server/src/sim.rs
@@ -171,18 +171,24 @@ async fn sim_loop(_room_id: String, mut rx: mpsc::Receiver<SimCommand>) {
                     if let Some(room) = room_ref.as_ref().and_then(|r| r.upgrade()) {
                         let mut room_guard = room.write().await;
                         let seq = room_guard.next_seq();
-                        let mut net_players = Vec::new();
-                        for (id, state) in players.iter() {
-                            if let Some(p) = room_guard.find_player_mut(id) {
-                                p.last_ack_tick = state.last_ack_tick;
-                                p.last_input_seq = state.last_input_seq;
+                        let mut net_players = Vec::with_capacity(room_guard.players.len());
+                        for player in room_guard.players.iter_mut() {
+                            let sim_state = players.get(&player.id);
+                            if let Some(state) = sim_state {
+                                player.last_ack_tick = state.last_ack_tick;
+                                player.last_input_seq = state.last_input_seq;
                             }
+                            let (x, y, vx, vy) = if let Some(state) = sim_state {
+                                (state.x, state.y, state.vx, state.vy)
+                            } else {
+                                (0.0, 0.0, 0.0, 0.0)
+                            };
                             net_players.push(NetPlayer {
-                                id: id.clone(),
-                                x: state.x,
-                                y: state.y,
-                                vx: state.vx,
-                                vy: state.vy,
+                                id: player.id.clone(),
+                                x,
+                                y,
+                                vx,
+                                vy,
                                 alive: true,
                             });
                         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -159,7 +159,21 @@ async fn lobby_to_start_flow() {
     let countdown_master = recv_type(&mut master_ws, "start_countdown").await;
     assert_eq!(countdown_master["payload"]["countdownSec"], 0);
     let _countdown_member = recv_type(&mut member_ws, "start_countdown").await;
-    let _start_master = recv_type(&mut master_ws, "start").await;
+    let start_master = recv_type(&mut master_ws, "start").await;
+    let start_roster = start_master["payload"]["players"].as_array().unwrap();
+    assert_eq!(
+        start_roster.len(),
+        2,
+        "start roster should list both players"
+    );
+    for pid in [&master_id, &member_id] {
+        assert!(
+            start_roster
+                .iter()
+                .any(|player| player["id"].as_str() == Some(pid)),
+            "start payload missing player {pid}"
+        );
+    }
     let _start_member = recv_type(&mut member_ws, "start").await;
 
     master_ws
@@ -174,6 +188,27 @@ async fn lobby_to_start_flow() {
         .unwrap();
     let snapshot = recv_type(&mut master_ws, "snapshot").await;
     assert!(snapshot["payload"]["tick"].as_u64().unwrap() >= 1);
+    let snap_players = snapshot["payload"]["players"].as_array().unwrap();
+    assert_eq!(
+        snap_players.len(),
+        2,
+        "snapshot should include both players"
+    );
+    let snapshot_member = recv_type(&mut member_ws, "snapshot").await;
+    let member_players = snapshot_member["payload"]["players"].as_array().unwrap();
+    assert_eq!(
+        member_players.len(),
+        2,
+        "member snapshot should include both players",
+    );
+    for pid in [&master_id, &member_id] {
+        assert!(
+            member_players
+                .iter()
+                .any(|player| player["id"].as_str() == Some(pid)),
+            "member snapshot missing player {pid}"
+        );
+    }
 
     shutdown.send(()).ok();
     handle.abort();

--- a/tests/network_spec.rs
+++ b/tests/network_spec.rs
@@ -375,6 +375,14 @@ async fn websocket_join_sequence_matches_spec() {
     let start = expect_outbound(&mut socket, "start").await;
     if let OutboundMessage::Start { payload, .. } = start {
         assert_eq!(payload.tps, state.config.tick_rate_hz);
+        assert!(
+            !payload.players.is_empty(),
+            "start payload must include at least the local player"
+        );
+        assert!(
+            payload.players.iter().any(|p| p.id == player_id),
+            "start payload missing local player"
+        );
     } else {
         panic!("expected start frame");
     }


### PR DESCRIPTION
## Summary
- build snapshot player lists from the room roster so every client receives the full set of active avatars
- keep lobby bookkeeping in sync with the simulation while defaulting positions for players who have not produced state yet
- extend the lobby-to-start integration test to assert that both connections observe the complete roster in snapshot frames

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d56b6548c0832d833324a5724ce095